### PR TITLE
Set schema target to OpenAPI 3

### DIFF
--- a/fastify-zod/src/index.ts
+++ b/fastify-zod/src/index.ts
@@ -20,7 +20,7 @@ export const buildJsonSchema = <$id extends string>(
   $id: $id,
 ): JsonSchema<$id> => ({
   $id,
-  ...zodToJsonSchema(ZodSchema),
+  ...zodToJsonSchema(ZodSchema, { target: "openApi3" }),
 });
 
 export const buildJsonSchemas = <$id extends string>(


### PR DESCRIPTION
Hi there,

This upgrades the output JSON schema to OpenAPI 3, most importantly producing `nullable` fields instead of `anyOf`, making it compliant with codegen tools such as https://github.com/drwpow/openapi-typescript. Nothing should break here, it works fine in my app.

Kind regards,
Hampus Kraft.