### PR TITLE
feat: allow passing a refStrategy option to zod-to-json-schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ const models = {
 
 Generates either `jsonSchema7` or `openApi3` schema. See [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema#options-object).
 
+##### `BuildJsonSchemasOptions.refStrategy: `jsonSchema7`|`openApi3` = "jsonSchema7"`: _jsonSchema7_ (default) or _openApi3_
+
+Uses either `root`, `relative` or `none` (default `root`) for the reference builder strategy. See [`zod-to-json-schema`](https://github.com/StefanTerdell/zod-to-json-schema#options-object) options object (`$refStrategy?`) for more information.
+
 #### `BuildJsonSchemasResult<typeof models> = { schemas: JsonSchema[], $ref: $ref<typeof models> }`
 
 The result of `buildJsonSchemas` has 2 components: an array of schemas that can be added directly to fastify using `fastify.addSchema`, and a `$ref` function that returns a `{ $ref: string }` object that can be used directly.

--- a/src/JsonSchema.ts
+++ b/src/JsonSchema.ts
@@ -6,6 +6,7 @@ export type BuildJsonSchemasOptions = {
   readonly $id?: string;
   readonly target?: `jsonSchema7` | `openApi3`;
   readonly errorMessages?: boolean;
+  readonly refStrategy?: `root` | `relative` | `none`;
 };
 
 export type $Ref<M extends Models> = (key: SchemaKeyOrDescription<M>) => {
@@ -43,6 +44,7 @@ export const buildJsonSchemas = <M extends Models>(
     target: opts.target,
     basePath: [`${$id}#`],
     errorMessages: opts.errorMessages,
+    $refStrategy: opts.refStrategy ?? `root`,
   });
 
   const jsonSchema: JsonSchema = {


### PR DESCRIPTION
Currently, when using [openapi-typescript-codegen](https://www.npmjs.com/package/openapi-typescript-codegen) to consume the generated `openapi.json` file from `fastify-zod` for my frontend, I encounter difficulties due to the incompatibility between the codegen types and the [default refStrategy options](https://github.com/StefanTerdell/zod-to-json-schema#options-object) options used in `zod-to-json-schema`.

To overcome this limitation and improve the integration between these two amazing tools (great work btw 😄), I propose the addition of a new `refStrategy` option in the `buildJSONSchema` options and pass this down to `zod-to-json-schema`. 

Thanks!